### PR TITLE
'NoSuchBucket' exception is thrown when an object doe…

### DIFF
--- a/src/Qcloud/Cos/ExceptionParser.php
+++ b/src/Qcloud/Cos/ExceptionParser.php
@@ -64,7 +64,7 @@ class ExceptionParser {
         } elseif ($method === 'HEAD' && $status === 404) {
             $path   = explode('/', trim($request->getPath(), '/'));
             $host   = explode('.', $request->getHost());
-            $bucket = (count($host) === 4) ? $host[0] : array_shift($path);
+            $bucket = (count($host) >= 4) ? $host[0] : array_shift($path);
             $object = array_shift($path);
 
             if ($bucket && $object) {


### PR DESCRIPTION
````php
$host   = explode('.', $request->getHost());
$bucket = (count($host) === 4) ? $host[0] : array_shift($path);
$object = array_shift($path);
if ($bucket && $object) {
    $data['code'] = 'NoSuchKey';
} elseif ($bucket) {
    $data['code'] = 'NoSuchBucket';
}
````

The host should be '{bucket}-{appid}.cos.{region}.myqcloud.com' for XML API. It means `count(explode('.', $request->getHost())` equals **5**, not **4**(That's JSON API's value). This make `$bucket` always be `array_shift($path)`, and `$object` always null;

I changed the condition from `count($host) === 4` to `count($host) >= 4`. It could resolve #32.