### PR TITLE
add sign string by Guzzle not concatenation directly.

### DIFF
--- a/src/Qcloud/Cos/Signature.php
+++ b/src/Qcloud/Cos/Signature.php
@@ -46,6 +46,7 @@ class Signature {
         $authorization = 'q-sign-algorithm=sha1&q-ak='. $this->accessKey .
             "&q-sign-time=$signTime&q-key-time=$signTime&q-header-list=host&q-url-param-list=&" .
             "q-signature=$signature";
-        return $request->getUrl()."?"."sign=".urlencode($authorization);
+        $request->getQuery()->add('sign', $authorization);
+        return $request->getUrl();
     }
 }


### PR DESCRIPTION
To fix bug that it doesn't work when get presigned url with expire time and  options like ResponseContentEncoding.

你好，在使用SDK的过程中遇到一个BUG.
在创建带签名的下载url时，如果同时带有其他参数如ResponseContentDisposition，生成的URL无法正常下载。
原因是增加sign参数时直接用?连接了url和签名。 所以将sign参数加到Guzzle request 中，由Guzzle生成URL