### PR TITLE
优化 sample.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+.idea/

--- a/sample.php
+++ b/sample.php
@@ -1,14 +1,17 @@
 <?php
 
-require(__DIR__ . DIRECTORY_SEPARATOR . 'cos-autoloader.php');
+require __DIR__ . DIRECTORY_SEPARATOR . 'cos-autoloader.php';
 
-$cosClient = new Qcloud\Cos\Client(array('region' => getenv('COS_REGION'),
-    'credentials'=> array(
+$cosClient = new Qcloud\Cos\Client(array(
+    'region' => getenv('COS_REGION'),
+    'credentials' => array(
         'appId' => getenv('COS_APPID'),
-        'secretId'    => getenv('COS_KEY'),
-        'secretKey' => getenv('COS_SECRET'))));
+        'secretId' => getenv('COS_KEY'),
+        'secretKey' => getenv('COS_SECRET'),
+    ),
+));
 
-//bucket的命名规则为{name}-{appid} ，此处填写的存储桶名称必须为此格式
+// 若初始化 Client 时未填写 appId，则 bucket 的命名规则为{name}-{appid} ，此处填写的存储桶名称必须为此格式
 $bucket = 'lewzylu02-1252448703';
 $key = 'a.txt';
 $local_path = "E:/a.txt";
@@ -20,10 +23,11 @@ try {
     $result = $cosClient->putObject(array(
         'Bucket' => $bucket,
         'Key' => $key,
-        'Body' => 'Hello World!'));
+        'Body' => 'Hello World!'
+    ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ### 上传文件流
@@ -31,10 +35,11 @@ try {
     $result = $cosClient->putObject(array(
         'Bucket' => $bucket,
         'Key' => $key,
-        'Body' => fopen($local_path, 'rb')));
+        'Body' => fopen($local_path, 'rb')
+    ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ### 设置header和meta
@@ -57,10 +62,11 @@ try {
         'Metadata' => array(
             'string' => 'string',
         ),
-        'StorageClass' => 'string'));
+        'StorageClass' => 'string'
+    ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## Upload(高级上传接口，默认使用分块上传最大支持50T)
@@ -69,10 +75,11 @@ try {
     $result = $cosClient->Upload(
         $bucket = $bucket,
         $key = $key,
-        $body = 'Hello World!');
+        $body = 'Hello World!'
+    );
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ### 上传文件流
@@ -80,16 +87,17 @@ try {
     $result = $cosClient->Upload(
         $bucket = $bucket,
         $key = $key,
-        $body = fopen($local_path, 'rb'));
+        $body = fopen($local_path, 'rb')
+    );
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ### 设置header和meta
 try {
     $result = $cosClient->upload(
-        $bucket= $bucket,
+        $bucket = $bucket,
         $key = $key,
         $body = fopen($local_path, 'rb'),
         $options = array(
@@ -107,10 +115,12 @@ try {
             'Metadata' => array(
                 'string' => 'string',
             ),
-            'StorageClass' => 'string'));
+            'StorageClass' => 'string'
+        )
+    );
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## 预签名上传createPresignedUrl
@@ -121,12 +131,12 @@ try {
     $command = $cosClient->getCommand('putObject', array(
         'Bucket' => $bucket,
         'Key' => $key,
-        'Body' => '' //Body可以任意
+        'Body' => '', //Body可以任意
     ));
     $signedUrl = $command->createPresignedUrl('+10 minutes');
     echo ($signedUrl);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ### 分块上传预签名
@@ -137,14 +147,13 @@ try {
         'Key' => $key,
         'UploadId' => $uploadId,
         'PartNumber' => '1',
-        'Body' => '' //Body可以任意
+        'Body' => '', //Body可以任意
     ));
     $signedUrl = $command->createPresignedUrl('+10 minutes');
     echo ($signedUrl);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 # 下载文件
 ## getObject(下载文件)
@@ -152,10 +161,11 @@ try {
 try {
     $result = $cosClient->getObject(array(
         'Bucket' => $bucket,
-        'Key' => $key));
-    echo($result['Body']);
+        'Key' => $key
+    ));
+    echo $result['Body'];
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ### 下载到本地
@@ -163,9 +173,10 @@ try {
     $result = $cosClient->getObject(array(
         'Bucket' => $bucket,
         'Key' => $key,
-        'SaveAs' => $local_path));
+        'SaveAs' => $local_path
+    ));
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ### 指定下载范围
@@ -177,9 +188,10 @@ try {
         'Bucket' => $bucket,
         'Key' => $key,
         'Range' => 'bytes=0-10',
-        'SaveAs' => $local_path));
+        'SaveAs' => $local_path
+    ));
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ### 设置返回header
@@ -193,19 +205,19 @@ try {
         'ResponseContentLanguage' => 'string',
         'ResponseContentType' => 'string',
         'ResponseExpires' => 'mixed type: string (date format)|int (unix timestamp)|\DateTime',
-        'SaveAs' => $local_path));
+        'SaveAs' => $local_path
+    ));
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## getObjectUrl(获取文件UrL)
 try {
     $signedUrl = $cosClient->getObjectUrl($bucket, $key, '+10 minutes');
-    echo ($signedUrl);
+    echo $signedUrl;
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 # 删除object
 ## deleteObject
@@ -213,12 +225,12 @@ try {
     $result = $cosClient->deleteObject(array(
         'Bucket' => $bucket,
         'Key' => $key,
-        'VersionId' => 'string'));
+        'VersionId' => 'string'
+    ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 # 删除多个object
 ## deleteObjects
@@ -235,9 +247,8 @@ try {
     ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 # 获取object信息
 ## headObject
@@ -248,13 +259,13 @@ try {
     $result = $cosClient->headObject(array(
         'Bucket' => $bucket,
         'Key' => '11',
-        'VersionId' =>'111',
-        'ServerSideEncryption' => 'AES256'));
+        'VersionId' => '111',
+        'ServerSideEncryption' => 'AES256'
+    ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 # 获取bucket列表
 ## listBuckets
@@ -262,9 +273,8 @@ try {
     $result = $cosClient->listBuckets();
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 # 创建bucket
 ## createBucket
@@ -272,20 +282,19 @@ try {
     $result = $cosClient->createBucket(array('Bucket' => $bucket));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 # 删除bucket
 ## deleteBucket
 try {
     $result = $cosClient->deleteBucket(array(
-        'Bucket' => $bucket));
+        'Bucket' => $bucket
+    ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 # 获取bucket信息
 ## headBucket
@@ -294,12 +303,12 @@ try {
  */
 try {
     $result = $cosClient->headBucket(array(
-        'Bucket' => $bucket));
+        'Bucket' => $bucket
+    ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 # 列出bucket下的object
 ## listObjects
@@ -309,26 +318,27 @@ try {
  */
 try {
     $result = $cosClient->listObjects(array(
-        'Bucket' => $bucket));
-    foreach ($result['Contents'] as $rt){
+        'Bucket' => $bucket
+    ));
+    foreach ($result['Contents'] as $rt) {
         print_r($rt);
     }
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ### 列出带有前缀的object
 try {
     $result = $cosClient->listObjects(array(
         'Bucket' => $bucket,
-        'Prefix' => 'string'));
-    foreach ($result['Contents'] as $rt){
+        'Prefix' => 'string'
+    ));
+    foreach ($result['Contents'] as $rt) {
         print_r($rt);
     }
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 # 获取bucket地域
 ## getBucketLocation
@@ -337,19 +347,19 @@ try {
         'Bucket' => 'lewzylu02',
     ));
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 };
-
 
 # 多版本相关
 ## putBucketVersioning(开启关闭某个bucket的多版本)
 try {
-    $result = $cosClient->putBucketVersioning(
-        array('Bucket' => $bucket,
-            'Status' => 'Enabled'));
+    $result = $cosClient->putBucketVersioning(array(
+        'Bucket' => $bucket,
+        'Status' => 'Enabled'
+    ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## ListObjectVersions(列出多版本object)
@@ -357,13 +367,13 @@ try {
  * 同名文件会出现多个版本
  */
 try {
-    $result = $cosClient->ListObjectVersions(
-        array('Bucket' => $bucket,
-            'Prefix'=>'string')
-    );
+    $result = $cosClient->ListObjectVersions(array(
+        'Bucket' => $bucket,
+        'Prefix' => 'string'
+    ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## getBucketVersioning(获取某个bucket多版本属性)
@@ -372,9 +382,8 @@ try {
         array('Bucket' => $bucket));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 # ACL相关
 ## putBucketACL(设置bucketACL)
@@ -395,19 +404,19 @@ try {
         'Owner' => array(
             'DisplayName' => 'qcs::cam::uin/3210232098:uin/3210232098',
             'ID' => 'qcs::cam::uin/3210232098:uin/3210232098',
-        ),));
+        )));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## getBucketACL(获取bucketACL)
 try {
     $result = $cosClient->GetBucketAcl(array(
-        'Bucket' => $bucket,));
+        'Bucket' => $bucket));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## putObjectACL(设置objectACL)
@@ -429,22 +438,21 @@ try {
         'Owner' => array(
             'DisplayName' => 'qcs::cam::uin/3210232098:uin/3210232098',
             'ID' => 'qcs::cam::uin/3210232098:uin/3210232098',
-        ),));
+        )));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## getObjectACL(获取objectACL)
 try {
     $result = $cosClient->GetObjectAcl(array(
         'Bucket' => $bucket,
-        'Key' => $key,));
+        'Key' => $key));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 # 生命周期相关
 ## putBucketLifecycle(设置bucket生命周期)
@@ -458,7 +466,7 @@ try {
                 ),
                 'ID' => 'id1',
                 'Filter' => array(
-                    'Prefix' => 'documents/'
+                    'Prefix' => 'documents/',
                 ),
                 'Status' => 'Enabled',
                 'Transitions' => array(
@@ -470,29 +478,28 @@ try {
         )));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## getBucketLifecycle(获取bucket生命周期)
 try {
     $result = $cosClient->getBucketLifecycle(array(
-        'Bucket' =>$bucket,
+        'Bucket' => $bucket,
     ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## deleteBucketLifecycle(删除bucket生命周期)
 try {
     $result = $cosClient->deleteBucketLifecycle(array(
-        'Bucket' =>$bucket,
+        'Bucket' => $bucket,
     ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 # 跨域相关
 ## putBucketCors(设置bucket跨域)
@@ -504,22 +511,21 @@ try {
                 'ID' => '1234',
                 'AllowedHeaders' => array('*'),
                 'AllowedMethods' => array('PUT'),
-                'AllowedOrigins' => array('http://www.qq.com', ),
+                'AllowedOrigins' => array('http://www.qq.com'),
             ),
         ),
     ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## getBucketCors(获取bucket跨域信息)
 try {
-    $result = $cosClient->getBucketCors(array(
-    ));
+    $result = $cosClient->getBucketCors(array());
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## deleteBucketCors(删除bucket跨域)
@@ -530,7 +536,7 @@ try {
     ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 # 复制
@@ -546,7 +552,7 @@ try {
     ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## Copy(分块并发复制)
@@ -554,13 +560,15 @@ try {
  * 将{bucket},{region},{cos_path},{versionId}替换成复制源的真实信息
  */
 try {
-    $result = $cosClient->Copy($bucket = $bucket,
+    $result = $cosClient->Copy(
+        $bucket = $bucket,
         $key = $key,
         $copysource = '{bucket}.cos.{region}.myqcloud.com/{cos_path}',
-        $options = array('VersionId'=>'{versionId}'));
+        $options = array('VersionId' => '{versionId}'
+    ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 # 恢复归档文件
@@ -571,45 +579,46 @@ try {
         'Key' => $key,
         'Days' => 7,
         'CASJobParameters' => array(
-            'Tier' =>'Bulk'
-        )
+            'Tier' => 'Bulk',
+        ),
     ));
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 # 其他服务
 ## 列出某bucket下所有的object
 try {
-    $prefix='';
-    $marker='';
-    while(True){
-        $result = $cosClient->ListObjects(
-            array('Bucket' => $bucket,
-                'Marker' => $marker,
-                'MaxKeys' => 1000));
+    $prefix = '';
+    $marker = '';
+    while (true) {
+        $result = $cosClient->ListObjects(array(
+            'Bucket' => $bucket,
+            'Marker' => $marker,
+            'MaxKeys' => 1000
+        ));
         foreach ($result['Contents'] as $rt) {
-            print_r($rt['Key']." ");
+            print_r($rt['Key'] . " ");
             /*
              * 使用下面的代码可以删除全部object
              */
-//            try {
-//                $result = $cosClient->deleteobjects(array(
-//                    'Bucket' => $bucket,
-//                    'Key' => $rt['Key']));
-//                print_r($result);
-//            } catch (\Exception $e) {
-//                echo "$e\n";
-//            }
+            // try {
+            //     $result = $cosClient->deleteobjects(array(
+            //         'Bucket' => $bucket,
+            //         'Key' => $rt['Key']));
+            //     print_r($result);
+            // } catch (\Exception $e) {
+            //     print_r($e);
+            // }
         }
         $marker = $result['NextMarker'];
-        if (!$result['IsTruncated']){
+        if (!$result['IsTruncated']) {
             break;
         }
     }
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## 删除所有因上传失败而产生的分块
@@ -617,19 +626,20 @@ try {
  * 可以清理掉因分块上传失败
  */
 try {
-    while(True){
+    while (true) {
         $result = $cosClient->ListMultipartUploads(
             array('Bucket' => $bucket,
                 'Prefix' => ''));
-        if (count($result['Uploads']) == 0){
+        if (count($result['Uploads']) == 0) {
             break;
         }
         foreach ($result['Uploads'] as $upload) {
             try {
-                $rt = $cosClient->AbortMultipartUpload(
-                    array('Bucket' => $bucket,
-                        'Key' => $upload['Key'],
-                        'UploadId' => $upload['UploadId']));
+                $rt = $cosClient->AbortMultipartUpload(array(
+                    'Bucket' => $bucket,
+                    'Key' => $upload['Key'],
+                    'UploadId' => $upload['UploadId']
+                ));
                 print_r($rt);
             } catch (\Exception $e) {
                 print_r($e);
@@ -637,7 +647,7 @@ try {
         }
     }
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
 
 ## 分块上传断点重传
@@ -649,13 +659,13 @@ try {
     $result = $cosClient->resumeUpload(
         $bucket = $bucket,
         $key = $key,
-        $body = fopen("E:/test.txt",'rb'),
-        $uploadId = '152448808231afdf221eb558ab15d1e455d2afd025c5663936142fdf5614ebf6d1668e2eda');
+        $body = fopen("E:/test.txt", 'rb'),
+        $uploadId = '152448808231afdf221eb558ab15d1e455d2afd025c5663936142fdf5614ebf6d1668e2eda'
+    );
     print_r($result);
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }
-
 
 ## 删除某些前缀的空bucket
 function startsWith($haystack, $needle)
@@ -666,23 +676,23 @@ function startsWith($haystack, $needle)
 
 try {
     $result = $cosClient->listBuckets();
-    foreach ($result['Buckets'] as $bucket){
+    foreach ($result['Buckets'] as $bucket) {
         $region = $bucket['Location'];
         $name = $bucket['Name'];
-        if (startsWith($name,'lewzylu')){
+        if (startsWith($name, 'lewzylu')) {
             try {
-                $cosClient2 = new Qcloud\Cos\Client(array('region' => $region,
-                    'credentials'=> array(
-                        'secretId'    => getenv('COS_KEY'),
-                        'secretKey' => getenv('COS_SECRET'))));
+                $cosClient2 = new Qcloud\Cos\Client(array(
+                    'region' => $region,
+                    'credentials' => array(
+                        'secretId' => getenv('COS_KEY'),
+                        'secretKey' => getenv('COS_SECRET'))
+                ));
                 $rt = $cosClient2->deleteBucket(array('Bucket' => $name));
                 print_r($rt);
-            }catch (\Exception $e) {
+            } catch (\Exception $e) {
             }
         }
-
-
     }
 } catch (\Exception $e) {
-    echo "$e\n";
+    print_r($e);
 }


### PR DESCRIPTION
例子太乱，优化一下格式。没有完善就不要放出来，哪怕没有让我们对着 API 手撸也比乱着强。

另外提几个建议：

- 管理控制台上展示的直接就是 API 域名，为毛 SDK 要给拆开再在内部手动拼接，怎么不做成类似阿里 OSS PHP SDK 的 `endPoint` 特性
- guzzle/guzzle 已经 abandon，啥时候更新一波
- 上传文件流既然 fopen 是外部控制，为何要在内部 close 掉

另外文档写的和 Github 不同步：<https://cloud.tencent.com/document/product/436/12266#.E9.85.8D.E7.BD.AE.E6.96.87.E4.BB.B6>，这里没有 `appId`。

想起几张图，自己感受下：

![image](https://user-images.githubusercontent.com/25447002/41329368-efd1a180-6eff-11e8-9c9b-c3cfa79aabe5.png)

![image](https://user-images.githubusercontent.com/25447002/41329384-fe29f610-6eff-11e8-93ae-0bac0adbc975.png)

![image](https://user-images.githubusercontent.com/25447002/41329394-097b5310-6f00-11e8-9300-fdd52cbb7aed.png)

