### PR TITLE
使用`guzzlehttp/guzzle`替代`guzzle/guzzle`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "guzzle/guzzle": "~3.7"
+        "guzzlehttp/guzzle": "~3.7"
     }
 }


### PR DESCRIPTION
composer 提示：
`Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.`