### PR TITLE
Fix XML parsing error (#95)

### DIFF
--- a/src/Qcloud/Cos/ExceptionParser.php
+++ b/src/Qcloud/Cos/ExceptionParser.php
@@ -27,7 +27,7 @@ class ExceptionParser {
         }
 
         try {
-            $xml = new \SimpleXMLElement($body);
+            $xml = new \SimpleXMLElement(utf8_encode($body));
             $this->parseBody($xml, $data);
             return $data;
         } catch (\Exception $e) {


### PR DESCRIPTION
Warning: SimpleXMLElement::__construct(): Entity: line 4: parser error : Input is not proper UTF-8, indicate encoding !