### PR TITLE
chore: 增加1.3版本支持修改domain

### DIFF
--- a/src/Qcloud/Cos/Client.php
+++ b/src/Qcloud/Cos/Client.php
@@ -54,8 +54,9 @@ class Client extends GSClient {
         $this->timeout = isset($config['timeout']) ? $config['timeout'] : 3600;
         $this->connect_timeout = isset($config['connect_timeout']) ? $config['connect_timeout'] : 3600;
         $this->signature = new signature($this->secretId, $this->secretKey);
+        $this->domain = isset($config['domain']) ? $config['domain'] : 'myqcloud.com';
         parent::__construct(
-            $this->schema.'://cos.' . $this->region . '.myqcloud.com/',    // base url
+            $this->schema.'://cos.' . $this->region . '.' . $this->domain . '/',   // base url
             array('request.options' => array('timeout' => $this->timeout, 'connect_timeout' => $this->connect_timeout),
             )); // show curl verbose or not
         $desc = ServiceDescription::factory(Service::getService());


### PR DESCRIPTION
1.3版本支持修改domain，初始化时未传入则默认为myqcloud.com。
示例：
$cosClient = new Qcloud\Cos\Client([
            'region' => $queryParam['region'],
            'domain' => "test.com"
            'credentials' => [
                'secretId' => " "xxxxxxxxxxxxxxxxxxxxxxx","
                'secretKey' => "xxxxxxxxxxxxxxxxxxxxxxx",
            ],
   ]);