### PR TITLE
修复 https 配置不生效问题

### DIFF
--- a/src/Qcloud/Cos/Client.php
+++ b/src/Qcloud/Cos/Client.php
@@ -35,7 +35,7 @@ class Client extends GuzzleClient {
 
     public function __construct($cosConfig) {
         $this->rawCosConfig = $cosConfig;
-        $this->cosConfig['schema'] = isset($cosConfig['schema']) ? $cosConfig['schema'] : 'http';
+        $this->cosConfig['scheme'] = isset($cosConfig['scheme']) ? $cosConfig['scheme'] : 'http';
         $this->cosConfig['region'] =  region_map($cosConfig['region']);
         $this->cosConfig['appId'] = isset($cosConfig['credentials']['appId']) ? $cosConfig['credentials']['appId'] : null;
         $this->cosConfig['secretId'] = isset($cosConfig['credentials']['secretId']) ? $cosConfig['credentials']['secretId'] : "";
@@ -69,7 +69,7 @@ class Client extends GuzzleClient {
         $handler->push($this::handleErrors());
         $this->signature = new Signature($this->cosConfig['secretId'], $this->cosConfig['secretKey'], $this->cosConfig['token']);
         $this->httpClient = new HttpClient([
-            'base_uri' => $this->cosConfig['schema'].'://cos.' . $this->cosConfig['region'] . '.myqcloud.com/',
+            'base_uri' => $this->cosConfig['scheme'].'://cos.' . $this->cosConfig['region'] . '.myqcloud.com/',
             'timeout' => $this->cosConfig['timeout'],
             'handler' => $handler,
             'proxy' => $this->cosConfig['proxy'],

--- a/src/Qcloud/Cos/CosTransformer.php
+++ b/src/Qcloud/Cos/CosTransformer.php
@@ -70,7 +70,7 @@ class CosTransformer {
         }
 
 
-        $path = $this->config['schema'].'://'. $host . $uri;
+        $path = $this->config['scheme'].'://'. $host . $uri;
         $uri = new Uri($path);
         $query = $request->getUri()->getQuery();
         if ($uri->getQuery() != $query && $uri->getQuery() != "") {


### PR DESCRIPTION
由于代码读取配置文件的 key 值误将 scheme 拼写为 schema，导致配置 https 无法生效，在 https 环境下加载 http 资源，站点页面会被浏览器标记为不安全，建议 REVIEW & MERGE，THX