### PR TITLE
fix expries may be null

### DIFF
--- a/src/Qcloud/Cos/Client.php
+++ b/src/Qcloud/Cos/Client.php
@@ -137,13 +137,13 @@ class Client extends GuzzleClient {
         return $this->signature->createPresignedUrl($request, $expires);
     }
 
-    public function getPresignetUrl($method, $args, $expires = null) {
+    public function getPresignetUrl($method, $args, $expires = "+30 minutes") {
         $command = $this->getCommand($method, $args);
         $request = $this->commandToRequestTransformer($command);
         return $this->createPresignedUrl($request, $expires);
     }
 
-    public function getObjectUrl($bucket, $key, $expires = null, array $args = array()) {
+    public function getObjectUrl($bucket, $key, $expires = "+30 minutes", array $args = array()) {
         $command = $this->getCommand('GetObject', $args + array('Bucket' => $bucket, 'Key' => $key));
         $request = $this->commandToRequestTransformer($command);
         return $this->createPresignedUrl($request, $expires)->__toString();

--- a/src/Qcloud/Cos/Signature.php
+++ b/src/Qcloud/Cos/Signature.php
@@ -20,6 +20,9 @@ class Signature {
         return $request->withHeader('Authorization', $authorization);
     }
     public function createAuthorization(RequestInterface $request, $expires = "+30 minutes") {
+        if (is_null($expires)) {
+            $expires = "+30 minutes";
+        }
         $signTime = (string)(time() - 60) . ';' . (string)(strtotime($expires));
         $httpString = strtolower($request->getMethod()) . "\n" . urldecode($request->getUri()->getPath()) .
             "\n\nhost=" . $request->getHeader("Host")[0]. "\n";


### PR DESCRIPTION
`expires` 在外面调用的默认值是 `null`

`(string)(strtotime(null)` 会是一个空值，会导致过期时间为空
这样生成的链接访问的时候报超时错误:

```xml
<Error>
<Code>AccessDenied</Code>
<Message>Request has expired</Message>
<ServerTime>2020-06-17T05:37:29Z</ServerTime>
```

建议判断一下 expires 是否为空