### PR TITLE
补充完成PHP SDK缺失的对象标签功能

### DIFF
--- a/sample/deleteObjectTagging.php
+++ b/sample/deleteObjectTagging.php
@@ -1,0 +1,25 @@
+<?php
+
+require dirname(__FILE__) . '/../vendor/autoload.php';
+
+$secretId = "COS_SECRETID"; //"云 API 密钥 SecretId";
+$secretKey = "COS_SECRETKEY"; //"云 API 密钥 SecretKey";
+$region = "ap-beijing"; //设置一个默认的存储桶地域
+$cosClient = new Qcloud\Cos\Client(
+    array(
+        'region' => $region,
+        'schema' => 'https', //协议头部，默认为http
+        'credentials'=> array(
+            'secretId'  => $secretId ,
+            'secretKey' => $secretKey)));
+try {
+    $result = $cosClient->deleteObjectTagging(array(
+        'Bucket' => 'examplebucket-125000000', //格式：BucketName-APPID
+        'Key' => 'exampleobject',
+    ));
+    // 请求成功
+    print_r($result);
+} catch (\Exception $e) {
+    // 请求失败
+    echo($e);
+}

--- a/sample/getObjectTagging.php
+++ b/sample/getObjectTagging.php
@@ -1,0 +1,25 @@
+<?php
+require dirname(__FILE__) . '/../vendor/autoload.php';
+
+$secretId = "COS_SECRETID"; //"云 API 密钥 SecretId";
+$secretKey = "COS_SECRETKEY"; //"云 API 密钥 SecretKey";
+$region = "ap-beijing"; //设置一个默认的存储桶地域
+$cosClient = new Qcloud\Cos\Client(
+    array(
+        'region' => $region,
+        'schema' => 'https', //协议头部，默认为http
+        'credentials' => array(
+            'secretId' => $secretId,
+            'secretKey' => $secretKey)));
+try {
+    $result = $cosClient->getObjectTagging(array(
+        'Bucket' => 'examplebucket-125000000', //格式：BucketName-APPID
+        'Key' => 'exampleobject'
+    ));
+    // 请求成功
+    print_r($result);
+} catch (\Exception $e) {
+    // 请求失败
+    echo($e);
+}
+

--- a/sample/putObjectTagging.php
+++ b/sample/putObjectTagging.php
@@ -1,0 +1,33 @@
+<?php
+
+require dirname(__FILE__) . '/../vendor/autoload.php';
+
+$secretId = "COS_SECRETID"; //"云 API 密钥 SecretId";
+$secretKey = "COS_SECRETKEY"; //"云 API 密钥 SecretKey";
+$region = "ap-beijing"; //设置一个默认的存储桶地域
+$cosClient = new Qcloud\Cos\Client(
+    array(
+        'region' => $region,
+        'schema' => 'https', //协议头部，默认为http
+        'credentials'=> array(
+            'secretId'  => $secretId ,
+            'secretKey' => $secretKey)));
+try {
+    $result = $cosClient->putObjectTagging(array(
+        'Bucket' => 'examplebucket-125000000', //格式：BucketName-APPID
+        'Key' => 'exampleobject',
+        'TagSet' => array(
+            array('Key'=>'key1',
+                'Value'=>'value1',
+            ),
+            array('Key'=>'key2',
+                'Value'=>'value2',
+            ),
+        ),
+    ));
+    // 请求成功
+    print_r($result);
+} catch (\Exception $e) {
+    // 请求失败
+    echo "$e\n";
+}

--- a/src/Qcloud/Cos/Service.php
+++ b/src/Qcloud/Cos/Service.php
@@ -1117,7 +1117,7 @@ class Service {
                         ),
                         'ContentMD5' => array(
                             'type' => array(
-                                'string',
+//                                'string',
                                 'boolean'
                             ),
                             'location' => 'header',
@@ -1232,7 +1232,7 @@ class Service {
                         ),
                         'ContentMD5' => array(
                             'type' => array(
-                                'string',
+//                                'string',
                                 'boolean'
                             ),
                             'location' => 'header',

--- a/src/Qcloud/Cos/Service.php
+++ b/src/Qcloud/Cos/Service.php
@@ -637,6 +637,80 @@ class Service {
                         ),
                     ),
                 ),
+                // 配置对象标签的方法.
+                'PutObjectTagging' => array(
+                    'httpMethod' => 'PUT',
+                    'uri' => '/{Bucket}{/Key*}?tagging',
+                    'class' => 'Qcloud\\Cos\\Command',
+                    'responseClass' => 'PutObjectTaggingOutput',
+                    'responseType' => 'model',
+                    'data' => array(
+                        'xmlRoot' => array(
+                            'name' => 'Tagging',
+                        ),
+                        'contentMd5' => true,
+                    ),
+                    'parameters' => array(
+                        'Bucket' => array(
+                            'required' => true,
+                            'type' => 'string',
+                            'location' => 'uri',
+                        ),
+                        'Key' => array(
+                            'required' => true,
+                            'type' => 'string',
+                            'location' => 'uri',
+                            'minLength' => 1,
+                            'filters' => array(
+                                'Qcloud\\Cos\\Client::explodeKey'
+                            )
+                        ),
+                        'TagSet' => array(
+                            'required' => true,
+                            'type' => 'array',
+                            'location' => 'xml',
+                            'items' => array(
+                                'name' => 'TagRule',
+                                'type' => 'object',
+                                'sentAs' => 'Tag',
+                                'properties' => array(
+                                    'Key' => array(
+                                        'required' => true,
+                                        'type' => 'string',
+                                    ),
+                                    'Value' => array(
+                                        'required' => true,
+                                        'type' => 'string',
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                // 获取对象标签信息的方法
+                'GetObjectTagging' => array(
+                    'httpMethod' => 'GET',
+                    'uri' => '/{Bucket}{/Key*}?tagging',
+                    'class' => 'Qcloud\\Cos\\Command',
+                    'responseClass' => 'GetObjectTaggingOutput',
+                    'responseType' => 'model',
+                    'parameters' => array(
+                        'Bucket' => array(
+                            'required' => true,
+                            'type' => 'string',
+                            'location' => 'uri',
+                        ),
+                        'Key' => array(
+                            'required' => true,
+                            'type' => 'string',
+                            'location' => 'uri',
+                            'minLength' => 1,
+                            'filters' => array(
+                                'Qcloud\\Cos\\Client::explodeKey'
+                            )
+                        )
+                    ),
+                ),
                 // 删除对象标签的方法
                 'DeleteObjectTagging' => array(
                     'httpMethod' => 'DELETE',
@@ -3574,6 +3648,45 @@ class Service {
                         ),
                     ),
                 ),
+                //设置对象标签
+                'PutObjectTaggingOutput' => array(
+                    'type' => 'object',
+                    'additionalProperties' => true,
+                    'properties' => array(
+                        'RequestId' => array(
+                            'location' => 'header',
+                            'sentAs' => 'x-cos-request-id',
+                        ),
+                    ),
+                ),
+                //查询对象标签
+                'GetObjectTaggingOutput' => array(
+                    'type' => 'object',
+                    'additionalProperties' => true,
+                    'properties' => array(
+                        'TagSet' => array(
+                            'type' => 'array',
+                            'location' => 'xml',
+                            'items' => array(
+                                'sentAs' => 'Tag',
+                                'type' => 'object',
+                                'properties' => array(
+                                    'Key' => array(
+                                        'type' => 'string',
+                                    ),
+                                    'Value' => array(
+                                        'type' => 'string',
+                                    ),
+                                ),
+                            ),
+                        ),
+                        'RequestId' => array(
+                            'location' => 'header',
+                            'sentAs' => 'x-cos-request-id',
+                        ),
+                    ),
+                ),
+                //删除对象标签
                 'DeleteObjectTaggingOutput' => array(
                     'type' => 'object',
                     'additionalProperties' => true,

--- a/src/Qcloud/Cos/Service.php
+++ b/src/Qcloud/Cos/Service.php
@@ -637,6 +637,30 @@ class Service {
                         ),
                     ),
                 ),
+                // 删除对象标签的方法
+                'DeleteObjectTagging' => array(
+                    'httpMethod' => 'DELETE',
+                    'uri' => '/{Bucket}{/Key*}?tagging',
+                    'class' => 'Qcloud\\Cos\\Command',
+                    'responseClass' => 'DeleteObjectTaggingOutput',
+                    'responseType' => 'model',
+                    'parameters' => array(
+                        'Bucket' => array(
+                            'required' => true,
+                            'type' => 'string',
+                            'location' => 'uri'
+                        ),
+                        'Key' => array(
+                            'required' => true,
+                            'type' => 'string',
+                            'location' => 'uri',
+                            'minLength' => 1,
+                            'filters' => array(
+                                'Qcloud\\Cos\\Client::explodeKey'
+                            )
+                        )
+                    )
+                ),
                 // 下载对象的方法.
                 'GetObject' => array(
                     'httpMethod' => 'GET',
@@ -3549,6 +3573,16 @@ class Service {
                             'sentAs' => 'x-cos-request-id',
                         ),
                     ),
+                ),
+                'DeleteObjectTaggingOutput' => array(
+                    'type' => 'object',
+                    'additionalProperties' => true,
+                    'properties' => array(
+                        'RequestId' => array(
+                            'location' => 'header',
+                            'sentAs' => 'x-cos-request-id'
+                        )
+                    )
                 ),
                 'GetObjectOutput' => array(
                     'type' => 'object',

--- a/src/Qcloud/Cos/Tests/COSTest.php
+++ b/src/Qcloud/Cos/Tests/COSTest.php
@@ -1798,6 +1798,65 @@ class COSTest extends \PHPUnit\Framework\TestCase
     }
 
     /*
+     * 正常put对象标签
+     * 200
+     */
+    public function testPutObjectTagging()
+    {
+        $key = '你好.txt';
+        $testTaggingKeys = array(
+            'key1', 'key2'
+        );
+        $testTaggingValues = array(
+            'value1', 'value2'
+        );
+        try {
+            $result = $this->cosClient->putObjectTagging(array(
+                // Bucket is required
+                'Bucket' => $this->bucket,
+                // Key(Object) is required
+                'Key' => $key,
+                // tagging(key-value) is required
+                'TagSet' => array(
+                    array('Key'=> $testTaggingKeys[0],
+                        'Value'=> $testTaggingValues[0],
+                    ),
+                    array('Key'=> $testTaggingKeys[1],
+                        'Value'=> $testTaggingValues[1],
+                    ),
+                )
+            ));
+            print_r($result);
+            $this->assertTrue(True);
+        } catch (ServiceResponseException $e) {
+            print $e;
+            $this->assertFalse(TRUE);
+        }
+    }
+
+    /*
+     * 正常get对象标签
+     * 200
+     */
+    public function testGetObjectTagging()
+    {
+        $key = '你好.txt';
+        try {
+            $result = $this->cosClient->getObjectTagging(array(
+                // Bucket is required
+                'Bucket' => $this->bucket,
+                // Key(Object) is required
+                'Key' => $key
+            ));
+            print_r($result);
+            $this->assertTrue(True);
+        } catch (ServiceResponseException $e) {
+            print $e;
+            $this->assertFalse(TRUE);
+        }
+    }
+
+    /*
      * 正常delete对象标签
      * 200
      */

--- a/src/Qcloud/Cos/Tests/COSTest.php
+++ b/src/Qcloud/Cos/Tests/COSTest.php
@@ -1797,4 +1797,25 @@ class COSTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    /*
+     * 正常delete对象标签
+     * 200
+     */
+    public function testDeleteObjectTagging()
+    {
+        $key = '你好.txt';
+        try {
+            $result = $this->cosClient->deleteObjectTagging(array(
+                // Bucket is required
+                'Bucket' => $this->bucket,
+                // Key(Object) is required
+                'Key' => $key
+            ));
+            print_r($result);
+            $this->assertTrue(True);
+        } catch (ServiceResponseException $e) {
+            print $e;
+            $this->assertFalse(TRUE);
+        }
+    }
 }


### PR DESCRIPTION
主要涉及以下部分
- 设置对象标签（覆盖而不是追加）
- 查询对象标签
- 删除对象标签（删除对应所有标签）

已完成相关UT以及sample编写