### PR TITLE
Add XDEBUG_MODE=coverage for executing PHPUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ notifications:
       - wjielai@tencent.com
       - fysntian@tencent.com
 
+env:
+  global:
+    - XDEBUG_MODE=coverage
+
 before_script:
   - composer install --prefer-dist --dev --no-interaction
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,8 +10,4 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <logging/>
-  <php>
-    <ini name="xdebug.mode" value="coverage"/>
-  </php>
 </phpunit>


### PR DESCRIPTION
https://github.com/sebastianbergmann/php-code-coverage/issues/834
https://travis-ci.community/t/xdebug-3-is-installed-by-default-breaking-builds/10748